### PR TITLE
Fix bug where remixes wouldn't be correctly tracked

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -54,8 +54,6 @@
             if (!playlistEntries.hasOwnProperty(lineFormat)) {
                 self.totalSongs++;
                 self.totalWaitSinceChange = 0;
-				console.log(lineFormat)
-				console.log(title)
                 playlistEntries[lineFormat] = {
                     artist: artist,
                     title: title,
@@ -145,4 +143,3 @@
     }
 
 })(-1,'prompt');
-

--- a/exporter.js
+++ b/exporter.js
@@ -24,7 +24,7 @@
                 duration = l.querySelectorAll('td[data-col="duration"] span')[0].textContent,
                 lineFormat;
             if (self.format == 'ivy') {
-                lineFormat = artist.replace('-', ' ').trim() + ' - ' + title.replace(/(.+?)\s*[\(\[].+[\)\]]\s*$/, '$1').trim();
+                lineFormat = artist.replace('-', ' ').trim() + ' - ' + title.trim();
             } else if (self.format == 'm3u') {
                 var durationParts = duration.split(':'),
                     totalSeconds;

--- a/exporter.js
+++ b/exporter.js
@@ -40,13 +40,13 @@
                 lineFormat = '#EXTINF:' + totalSeconds + ','
                     + artist.replace('-', ' ').trim()
                     + ' - '
-                    + title.replace(/(.+?)\s*[\(\[].+[\)\]]\s*$/, '$1').trim()
+                    + title.trim()
                     + "\n"
                     + album.trim()
                     + '/'
                     + artist.replace('-', ' ').trim()
                     + ' - '
-                    + title.replace(/(.+?)\s*[\(\[].+[\)\]]\s*$/, '$1').trim()
+                    + title.trim()
                     + '.mp3'
             } else {
                 lineFormat = quoteEscape(artist)+','+quoteEscape(title)+','+quoteEscape(album)+','+quoteEscape(duration);
@@ -54,6 +54,8 @@
             if (!playlistEntries.hasOwnProperty(lineFormat)) {
                 self.totalSongs++;
                 self.totalWaitSinceChange = 0;
+				console.log(lineFormat)
+				console.log(title)
                 playlistEntries[lineFormat] = {
                     artist: artist,
                     title: title,
@@ -143,3 +145,4 @@
     }
 
 })(-1,'prompt');
+


### PR DESCRIPTION
I don't know if this breaks something else, but I had about five remixes of the same song that just placed duplicates of the original in a M3U. This pull seems to have fixed that.
